### PR TITLE
paginate the response of the GET /posts endpoint and fix bugs with the search post flow

### DIFF
--- a/src/api/helpers/getPagination.js
+++ b/src/api/helpers/getPagination.js
@@ -1,0 +1,15 @@
+const getPagination = ({ page, limit, total }) => {
+  const totalPages = Math.ceil(total / limit)
+  const prevPage = page <= 1 ? null : page - 1
+  const nextPage = page >= totalPages ? null : page + 1
+  return {
+    totalMatches: total,
+    totalPages,
+    prevPage,
+    currPage: page,
+    nextPage,
+    limit
+  }
+}
+
+export { getPagination }

--- a/src/api/v1/controllers/postController.js
+++ b/src/api/v1/controllers/postController.js
@@ -1,4 +1,5 @@
 import { REPORT_ACTIONS, REPORT_TYPES } from '../../../config/index.js'
+import { getPagination } from '../../helpers/getPagination.js'
 import { create, getById, getAll, updateById, deleteById } from '../models/postModel.js'
 import { createReport, closeReasonRelatedReports, closeAllReportsByResourceId } from '../models/reportModel.js'
 import { voteById } from '../models/votingModel.js'
@@ -20,10 +21,14 @@ const getPostById = async (req, res) => {
 }
 
 const getPosts = async (req, res) => {
-  const data = await getAll({ currUserId: req?.user?.id })
+  const { posts, ...result } = await getAll({ currUserId: req?.user?.id, ...req.query })
+  const pagination = getPagination(result)
   res.status(200).json({
     status: 'success',
-    data
+    data: {
+      posts,
+      ...pagination
+    }
   })
 }
 

--- a/src/api/v1/controllers/searchController.js
+++ b/src/api/v1/controllers/searchController.js
@@ -1,3 +1,4 @@
+import { getPagination } from '../../helpers/getPagination.js'
 import { getPostsByQuery } from '../models/postModel.js'
 import { searchModel } from '../models/searchModel.js'
 
@@ -14,20 +15,13 @@ const searchController = async (req, res) => {
 
 const searchPosts = async (req, res) => {
   const currUserId = req?.resource?.user?.id
-  const { total, page, limit, posts } = await getPostsByQuery({ ...req.query, currUserId })
-  const totalPages = Math.ceil(total / limit)
-  const prevPage = page <= 1 ? null : page - 1
-  const nextPage = page >= totalPages ? null : page + 1
+  const { posts, ...result } = await getPostsByQuery({ ...req.query, currUserId })
+  const pagination = getPagination(result)
   res.status(200).json({
     status: 'success',
     data: {
       posts,
-      limit,
-      totalMatches: total,
-      totalPages,
-      nextPage,
-      currPage: page,
-      prevPage
+      ...pagination
     }
   })
 }

--- a/src/api/v1/dtos/searchDto.js
+++ b/src/api/v1/dtos/searchDto.js
@@ -88,7 +88,7 @@ const transformPostPagination = ({ query }) => {
 
 const transformPostSearch = ({ query }) => {
   query.title = `%${query.title}%`
-  return transformPostPagination(query)
+  return transformPostPagination({ query })
 }
 
 // DTOs

--- a/src/api/v1/models/postModel.js
+++ b/src/api/v1/models/postModel.js
@@ -225,6 +225,7 @@ const existsById = async (postId) => {
 }
 
 const getPostsByQuery = async ({ title, sort, order, category, page, limit, currUserId }) => {
+  console.log({ category })
   const selectPosts = `WITH counted_posts AS (
                           SELECT
                             *,
@@ -234,7 +235,7 @@ const getPostsByQuery = async ({ title, sort, order, category, page, limit, curr
                           LEFT JOIN vote V
                             ON P.id = V.aspect_id AND V.user_id = $1
                           WHERE P.title ILIKE $2
-                            AND (P.category_id = $3 OR P.category_id IS NOT NULL)
+                            AND (P.category_id = $3 OR P.category_id IS NULL OR P.category_id = '')
                             AND P.deleted_at IS NULL
                         )
                         SELECT

--- a/src/api/v1/models/postModel.js
+++ b/src/api/v1/models/postModel.js
@@ -80,59 +80,67 @@ const getById = async ({ postId, currUserId }) => {
   return visiblePostData
 }
 
-const getAll = async ({ currUserId }) => {
-  const selectPosts = `SELECT
-                        A.id,
-                        A.title,
-                        A.body,
-                        A.category_id AS "categoryId",
-                        A.slug,
-                        A.author_id AS "authorId",
-                        U.username AS "authorUsername",
-                        U.avatar_url AS "avatarUrl",
-                        A.vote_count AS "voteCount",
-                        A.comment_count AS "commentCount",
-                        A.created_at AS "createdAt",
-                        A.updated_at AS "updatedAt",
-                        A.has_open_report AS "hasOpenReport",
-                        U.deleted_at AS "userDeletedAt"
-                      FROM aspect A
-                      LEFT JOIN "user" U
-                      ON A.author_id = U.id
-                      WHERE A.deleted_at IS NULL;`
-
-  const { rows: rawPostsData } = await pool.query(selectPosts)
-
-  const postVotes = {}
-
-  if (currUserId !== undefined) {
-    const selectPostVotes = `SELECT
-                              V.vote_direction AS "voteDirection",
-                              V.aspect_id AS "aspectId"
-                            FROM aspect A
-                            JOIN vote V
-                            ON A.id = V.aspect_id
-                            WHERE A.aspect_type_id = $1
-                            AND V.user_id = $2;`
-    const { rows: rawPostsVotes } = await pool.query(selectPostVotes, [ASPECT_TYPES.POST, currUserId])
-
-    rawPostsVotes.forEach(({ voteDirection, aspectId }) => {
-      postVotes[aspectId] = voteDirection
-    })
+const getAll = async ({ sort, order, category, page, limit, currUserId }) => {
+  const selectPosts = `WITH counted_posts AS (
+                          SELECT
+                            P.id,
+                            P.title,
+                            P.body,
+                            P.category_id AS "categoryId",
+                            P.slug,
+                            P.author_id AS "authorId",
+                            A.username AS "authorUsername",
+                            A.avatar_url AS "avatarUrl",
+                            P.vote_count AS post_vote_count,
+                            P.comment_count AS "commentCount",
+                            P.created_at AS post_created_at,
+                            P.updated_at AS "updatedAt",
+                            COALESCE(V.vote_direction, 0) AS "voteDirection",
+                            P.has_open_report AS "hasOpenReport",
+                            COUNT(P.id) OVER() as total
+                          FROM aspect P
+                          JOIN "user" A
+                            ON P.author_id = A.id
+                          LEFT JOIN vote V
+                            ON P.id = V.aspect_id AND V.user_id = $1
+                          LEFT JOIN "user" U
+                            ON U.id = V.user_id
+                          -- WHERE (P.category_id IS NOT NULL OR $2 IS NULL)
+                          WHERE (P.category_id = $2 OR $2 IS NULL OR $2 = '')
+                            AND P.deleted_at IS NULL
+                            AND P.deleted_at IS NULL
+                          )
+                        SELECT
+                          *,
+                          CP.post_vote_count AS "voteCount",
+                          CP.post_created_at AS "createdAt",
+                          CP.total::int
+                        FROM counted_posts CP
+                        ORDER BY post_${sort} ${order}
+                        LIMIT ${limit}
+                        OFFSET ${(page - 1) * limit};`
+  const { rows } = await pool.query(selectPosts, [currUserId, category])
+  if (rows.length === 0) {
+    return {
+      total: 0,
+      page: 1,
+      limit,
+      posts: []
+    }
   }
 
-  const visiblePostsData = rawPostsData.map(rawPost => {
-    if (rawPost.userDeletedAt) {
-      rawPost.authorId = null
-      rawPost.username = null
-      rawPost.avatarUrl = null
-    }
-    rawPost.voteDirection = postVotes[rawPost.id] || 0
-    const { userDeletedAt, ...visiblePostData } = rawPost
-    return visiblePostData
+  const { total } = rows[0]
+  const posts = rows.map(row => {
+    const { total, post_vote_count: _pVC, post_created_at: _pCA, ...post } = row
+    return post
   })
 
-  return visiblePostsData
+  return {
+    total,
+    page,
+    limit,
+    posts
+  }
 }
 
 const updateById = async ({ postId, title, body, categoryId, slug, currUserId }) => {

--- a/src/api/v1/routes/postRouter.js
+++ b/src/api/v1/routes/postRouter.js
@@ -22,13 +22,14 @@ import {
 import { postDto } from '../dtos/postDto.js'
 import { voteDto } from '../dtos/voteDto.js'
 import { createReportDto } from '../dtos/reportDto.js'
+import { postPaginationDto } from '../dtos/searchDto.js'
 
 const router = Router()
 
 router
   .route('/')
   .post([requireLoggedIn, isMuted, postDto], errorCatcher(createPost))
-  .get(setUserIfLoggedIn, getPosts)
+  .get(setUserIfLoggedIn, postPaginationDto, getPosts)
   .all(methodNotAllowedHandler)
 
 router


### PR DESCRIPTION
- create a helper function to calculate the pagination fields in the responses
- paginate the results of the GET /posts endpoint and add support for filtering and sorting results
- fix bugs with the search and pagination DTOs and the result filtering in the postModel, and use the getPagination helper function to refactor code in the search controller